### PR TITLE
Replace window checking idle loop with a timeout

### DIFF
--- a/maximus-two@wilfinitlike.gmail.com/decoration.js
+++ b/maximus-two@wilfinitlike.gmail.com/decoration.js
@@ -204,15 +204,18 @@ function onWindowAdded(ws, win) {
 	 * (see workspace.js _doAddWindow)
 	 */
 	if (!win.get_compositor_private()) {
-		Mainloop.idle_add(function () {
-			onWindowAdded(ws, win);
-			return false;
+		Mainloop.timeout_add(20, function () {
+			if(win.get_compositor_private()) {
+				onWindowAdded(ws, win);
+				return false;
+			}
+			return true;
 		});
 		return false;
 	}
 
 	let retry = 3;
-	Mainloop.idle_add(function () {
+	Mainloop.timeout_add(20, function () {
 		let id = guessWindowXID(win);
 		if (!id) {
 			if (--retry) {


### PR DESCRIPTION
Also, make sure the onWindowAdded callback is only called once when the
window is already properly added to the compositor. Keep the timeout
running otherwise, instead of setting a new one up every time.

This seems to fix #32 for me, but needs more testing, and testing on GNOME versions other than 3.16.
