### PR TITLE
update signals for shell 3.18

### DIFF
--- a/maximus-two@wilfinitlike.gmail.com/app_menu.js
+++ b/maximus-two@wilfinitlike.gmail.com/app_menu.js
@@ -214,8 +214,7 @@ function enable() {
 
 	focusCallbackID = Shell.WindowTracker.get_default().connect('notify::focus-app', onFocusChange);
 
-	wmCallbackIDs.push(global.window_manager.connect('maximize', updateAppMenu));
-	wmCallbackIDs.push(global.window_manager.connect('unmaximize', updateAppMenu));
+	wmCallbackIDs.push(global.window_manager.connect('size-change', updateAppMenu));
 
 	// note: 'destroy' needs a delay for .list_windows() report correctly
 	wmCallbackIDs.push(global.window_manager.connect('destroy', function () {

--- a/maximus-two@wilfinitlike.gmail.com/app_menu.js
+++ b/maximus-two@wilfinitlike.gmail.com/app_menu.js
@@ -8,6 +8,9 @@ const Tweener = imports.ui.tweener;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Util = Me.imports.util;
+const versionCompare = Me.imports.version_compare.versionCompare;
+
+const shell_version = imports.misc.config.PACKAGE_VERSION;
 
 function LOG(message) {
 	// log("[maximus-two]: " + message);
@@ -214,7 +217,12 @@ function enable() {
 
 	focusCallbackID = Shell.WindowTracker.get_default().connect('notify::focus-app', onFocusChange);
 
-	wmCallbackIDs.push(global.window_manager.connect('size-change', updateAppMenu));
+	if (versionCompare(shell_version, "3.17.4") >= 0) {
+		wmCallbackIDs.push(global.window_manager.connect('size-change', updateAppMenu));
+	} else {
+		wmCallbackIDs.push(global.window_manager.connect('maximize', updateAppMenu));
+		wmCallbackIDs.push(global.window_manager.connect('unmaximize', updateAppMenu));
+	}
 
 	// note: 'destroy' needs a delay for .list_windows() report correctly
 	wmCallbackIDs.push(global.window_manager.connect('destroy', function () {

--- a/maximus-two@wilfinitlike.gmail.com/metadata.json
+++ b/maximus-two@wilfinitlike.gmail.com/metadata.json
@@ -3,7 +3,7 @@
   "description": "Removes the title bar on maximised windows.\n Based on Pixel Saver (use Window Buttons to get the buttons (you can configure them then)\n You should be able to use the original Maximus extension if you have 3.4 or 3.6\nPlease report bugs on the github issues page: https://github.com/wilfm/GnomeExtensionMaximusTwo/issues\nNote you need xprop installed for this to work - see the github page for help with which package to install.",
   "name": "Maximus Two",
   "shell-version": [
-    "3.16"
+    "3.18"
   ],
   "url": "https://github.com/wilfm/GnomeExtensionMaximusTwo",
   "uuid": "maximus-two@wilfinitlike.gmail.com",

--- a/maximus-two@wilfinitlike.gmail.com/metadata.json
+++ b/maximus-two@wilfinitlike.gmail.com/metadata.json
@@ -3,6 +3,7 @@
   "description": "Removes the title bar on maximised windows.\n Based on Pixel Saver (use Window Buttons to get the buttons (you can configure them then)\n You should be able to use the original Maximus extension if you have 3.4 or 3.6\nPlease report bugs on the github issues page: https://github.com/wilfm/GnomeExtensionMaximusTwo/issues\nNote you need xprop installed for this to work - see the github page for help with which package to install.",
   "name": "Maximus Two",
   "shell-version": [
+    "3.16",
     "3.18"
   ],
   "url": "https://github.com/wilfm/GnomeExtensionMaximusTwo",

--- a/maximus-two@wilfinitlike.gmail.com/version_compare.js
+++ b/maximus-two@wilfinitlike.gmail.com/version_compare.js
@@ -1,0 +1,76 @@
+/**
+ * Compares two software version numbers (e.g. "1.7.1" or "1.2b").
+ *
+ * This function was born in http://stackoverflow.com/a/6832721.
+ *
+ * @param {string} v1 The first version to be compared.
+ * @param {string} v2 The second version to be compared.
+ * @param {object} [options] Optional flags that affect comparison behavior:
+ * <ul>
+ *     <li>
+ *         <tt>lexicographical: true</tt> compares each part of the version strings lexicographically instead of
+ *         naturally; this allows suffixes such as "b" or "dev" but will cause "1.10" to be considered smaller than
+ *         "1.2".
+ *     </li>
+ *     <li>
+ *         <tt>zeroExtend: true</tt> changes the result if one version string has less parts than the other. In
+ *         this case the shorter string will be padded with "zero" parts instead of being considered smaller.
+ *     </li>
+ * </ul>
+ * @returns {number|NaN}
+ * <ul>
+ *    <li>0 if the versions are equal</li>
+ *    <li>a negative integer iff v1 < v2</li>
+ *    <li>a positive integer iff v1 > v2</li>
+ *    <li>NaN if either version string is in the wrong format</li>
+ * </ul>
+ *
+ * @copyright by Jon Papaioannou (["john", "papaioannou"].join(".") + "@gmail.com")
+ * @license This function is in the public domain. Do what you want with it, no strings attached.
+ */
+function versionCompare(v1, v2, options) {
+    var lexicographical = options && options.lexicographical,
+        zeroExtend = options && options.zeroExtend,
+        v1parts = v1.split('.'),
+        v2parts = v2.split('.');
+
+    function isValidPart(x) {
+        return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
+    }
+
+    if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
+        return NaN;
+    }
+
+    if (zeroExtend) {
+        while (v1parts.length < v2parts.length) v1parts.push("0");
+        while (v2parts.length < v1parts.length) v2parts.push("0");
+    }
+
+    if (!lexicographical) {
+        v1parts = v1parts.map(Number);
+        v2parts = v2parts.map(Number);
+    }
+
+    for (var i = 0; i < v1parts.length; ++i) {
+        if (v2parts.length == i) {
+            return 1;
+        }
+
+        if (v1parts[i] == v2parts[i]) {
+            continue;
+        }
+        else if (v1parts[i] > v2parts[i]) {
+            return 1;
+        }
+        else {
+            return -1;
+        }
+    }
+
+    if (v1parts.length != v2parts.length) {
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Since gnome-shell version 3.18, the 'maximize' and 'unmaximize' signals were replaced by a single 'size-change' signal. The extension seems to work without fixing these errors, but makes gnome-tweak-tool and extensions.gnome.org refuse to activate it.

This is an extension of #40. As I do not know whether it is possible to push commits onto a pull request that I do not own, I created this new pull request containing both changes.
